### PR TITLE
Make default your browser location with Geolocator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# Acquire browser location by IP address
+gem "geocoder"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
+    geocoder (1.8.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
@@ -305,6 +306,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  geocoder
   importmap-rails
   jbuilder
   puma (~> 5.0)

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -1,6 +1,8 @@
 class ForecastsController < ApplicationController
   def index
-    location = params[:q].present? ? params[:q] : "46615"
+    # If Geocoder can't find your location, then view New York's
+    browser_location = request.location.postal_code || "New York"
+    location = params[:q].present? ? params[:q] : browser_location
     @forecast_data = WeatherApiService.new(location).request_forecast_data
   end
 end

--- a/app/views/forecasts/index.html.erb
+++ b/app/views/forecasts/index.html.erb
@@ -3,7 +3,7 @@
     <div class="col-12 col-md-8 col-lg-6 col-xl-4">
       <%= form_with url: forecasts_index_path, method: :get do |form| %>
         <div class="input-group mt-5 mb-3">
-          <%= form.text_field :q, { class: "form-control", placeholder: @forecast_data[:location], aria: { label: "Search for address by zip or city name", describedby: "basic-addon2" } } %>
+          <%= form.text_field :q, { class: "form-control", placeholder: "Search by city or zip", aria: { label: "Search for address by zip or city name", describedby: "basic-addon2" } } %>
           <span class="input-group-text" id="basic-addon2">
             <% if @forecast_data[:live_request] %>
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-broadcast-pin" viewBox="0 0 16 16">
@@ -18,6 +18,7 @@
         </div>
         <%= form.submit "Search", style: "display: none;" %>
       <% end %>
+      <p class="lead text-center"><%= @forecast_data[:location] %></p>
     </div>
   </div>
   <div class="row justify-content-center">

--- a/app/views/forecasts/index.html.erb
+++ b/app/views/forecasts/index.html.erb
@@ -4,7 +4,7 @@
       <%= form_with url: forecasts_index_path, method: :get do |form| %>
         <div class="input-group mt-5 mb-3">
           <%= form.text_field :q, { class: "form-control", placeholder: "Search by city or zip", aria: { label: "Search for address by zip or city name", describedby: "basic-addon2" } } %>
-          <span class="input-group-text" id="basic-addon2">
+          <span class="input-group-text" id="basic-addon2" title="<%= @forecast_data[:live_request] ? "Cache miss, Live Request" : "Cache HIT!" %>">
             <% if @forecast_data[:live_request] %>
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-broadcast-pin" viewBox="0 0 16 16">
                 <path d="M3.05 3.05a7 7 0 0 0 0 9.9.5.5 0 0 1-.707.707 8 8 0 0 1 0-11.314.5.5 0 0 1 .707.707zm2.122 2.122a4 4 0 0 0 0 5.656.5.5 0 1 1-.708.708 5 5 0 0 1 0-7.072.5.5 0 0 1 .708.708zm5.656-.708a.5.5 0 0 1 .708 0 5 5 0 0 1 0 7.072.5.5 0 1 1-.708-.708 4 4 0 0 0 0-5.656.5.5 0 0 1 0-.708zm2.122-2.12a.5.5 0 0 1 .707 0 8 8 0 0 1 0 11.313.5.5 0 0 1-.707-.707 7 7 0 0 0 0-9.9.5.5 0 0 1 0-.707zM6 8a2 2 0 1 1 2.5 1.937V15.5a.5.5 0 0 1-1 0V9.937A2 2 0 0 1 6 8z"/>

--- a/spec/requests/forecasts_spec.rb
+++ b/spec/requests/forecasts_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Forecasts", type: :request do
     it "returns http success" do
       stub_request(:get, "http://api.weatherapi.com/v1/forecast.json?days=3&key=asdf&q=46615")
         .to_return(body: fake_response, status: 200)
-      get "/forecasts/index", params: { q: "46615" }
+      get "/forecasts/index", params: {q: "46615"}
       expect(response).to have_http_status(:success)
     end
 

--- a/spec/requests/forecasts_spec.rb
+++ b/spec/requests/forecasts_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe "Forecasts", type: :request do
     it "returns http success" do
       stub_request(:get, "http://api.weatherapi.com/v1/forecast.json?days=3&key=asdf&q=46615")
         .to_return(body: fake_response, status: 200)
+      get "/forecasts/index", params: { q: "46615" }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "gracefully handles no location from the browser" do
+      stub_request(:get, "http://api.weatherapi.com/v1/forecast.json?days=3&key=asdf&q=New York")
+        .to_return(body: fake_response, status: 200)
       get "/forecasts/index"
       expect(response).to have_http_status(:success)
     end


### PR DESCRIPTION
If Geocoder can't find your location, then view New York's as a fallback. Also add a tooltip to the icons to help UX.