### PR TITLE
Gracefully handle error codes from API

### DIFF
--- a/app/services/weather_api_service.rb
+++ b/app/services/weather_api_service.rb
@@ -12,13 +12,21 @@ class WeatherApiService
 
   # Tie everything together and return the data hash
   def request_forecast_data
-    {
-      location: raw_response_hash["location"]["name"],
-      live_request: @client.live_request,
-      days: raw_response_hash["forecast"]["forecastday"].map do |raw_day_response|
-        massage_day_block(raw_day_response)
-      end
-    }
+    if raw_response_hash.key?("error")
+      {
+        error: raw_response_hash["error"]["message"],
+        live_request: @client.live_request,
+        days: []
+      }
+    else
+      {
+        location: raw_response_hash["location"]["name"],
+        live_request: @client.live_request,
+        days: raw_response_hash["forecast"]["forecastday"].map do |raw_day_response|
+          massage_day_block(raw_day_response)
+        end
+      }
+    end
   end
 
   private

--- a/app/views/forecasts/index.html.erb
+++ b/app/views/forecasts/index.html.erb
@@ -18,7 +18,7 @@
         </div>
         <%= form.submit "Search", style: "display: none;" %>
       <% end %>
-      <p class="lead text-center"><%= @forecast_data[:location] %></p>
+      <p class="lead text-center"><%= @forecast_data[:location] || @forecast_data[:error] %></p>
     </div>
   </div>
   <div class="row justify-content-center">

--- a/spec/fixtures/fake_no_location_found_response.json
+++ b/spec/fixtures/fake_no_location_found_response.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": 1006,
+    "message": "No matching location found."
+  }
+}


### PR DESCRIPTION
Don't bomb out. Instead display the returning error message to the user.